### PR TITLE
Add French cmd locale

### DIFF
--- a/locale/fr-fr/Run.voc
+++ b/locale/fr-fr/Run.voc
@@ -1,0 +1,1 @@
+(lance|exécute|démarre) (la|le|) (commande|script)

--- a/locale/fr-fr/running.dialog
+++ b/locale/fr-fr/running.dialog
@@ -1,0 +1,1 @@
+J'exécute {alias}.

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,6 @@
+{
+  "examples": [
+    "lance la commande ___",
+    "exécute le script ___"
+  ]
+}

--- a/translations/fr-fr/dialogs.json
+++ b/translations/fr-fr/dialogs.json
@@ -1,0 +1,5 @@
+{
+  "running.dialog": [
+    "J'exécute {alias}."
+  ]
+}

--- a/translations/fr-fr/vocabs.json
+++ b/translations/fr-fr/vocabs.json
@@ -1,0 +1,5 @@
+{
+  "Run.voc": [
+    "(lance|exécute|démarre) (la|le|) (commande|script)"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a complete French locale for the cmd skill, including spoken prompts, examples, and translation snapshots.

## Validation
- locale coverage compared against the English source locale
- JSON translation files parse cleanly
- git diff --check
